### PR TITLE
First drop of liballuxio code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([libtachyon], [0.1.0], [ryanhuang@cs.ucsd.edu])
+AC_CONFIG_MACRO_DIR([m4])
 
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD

--- a/env.sh
+++ b/env.sh
@@ -1,3 +1,6 @@
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-1.7.0-openjdk/jre/lib/amd64/server
 # export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home/jre/lib/server
 export CLASSPATH=$CLASSPATH:$HOME/tachyon/lib/tachyon-client-0.6.4-jar-with-dependencies.jar
+export CLASSPATH=$CLASSPATH:$HOME/alluxio/core/client/target/alluxio-core-client-1.0.1-jar-with-dependencies.jar
+

--- a/src/Alluxio.cc
+++ b/src/Alluxio.cc
@@ -1,0 +1,659 @@
+/**
+ *  @author        Adam Storm <ajstorm@ca.ibm.com>
+ *  @organization  IBM
+ * 
+ * Alluxio C/C++ APIs
+ *
+ */
+
+#include "Alluxio.h"
+#include "Util.h"
+
+#include <string>
+#include <string.h>
+#include <stdlib.h>
+#include <iostream>
+#include <chrono>
+
+using namespace alluxio;
+using namespace alluxio::jni;
+
+AlluxioClientContext::AlluxioClientContext(const char *host, const char *port)
+{
+    Env env;
+    jvalue  retClientContext;
+    jvalue  retConfiguration;
+    jvalue  retSet;
+    jstring jHostString;
+    jstring jPortString;
+    jobject jHostKeyString;
+    jobject jPortKeyString;
+
+    // First get the ClientContext.Configuration
+    env.callStaticMethod(&retConfiguration, 
+            "alluxio/client/ClientContext", "getConf", "()Lalluxio/Configuration;");
+
+    // Get the hostname and port strings from the alluxio.Constants class
+    jHostKeyString = env.getEnumObject(
+          "alluxio/Constants", "MASTER_HOSTNAME", "Ljava/lang/String;");
+    jPortKeyString = env.getEnumObject(
+          "alluxio/Constants", "MASTER_RPC_PORT", "Ljava/lang/String;"); 
+
+    jHostString = env.newStringUTF(host, "host");
+    jPortString = env.newStringUTF(port, "port");
+
+    // Call the methods to set the hostname and port
+    env.callMethod(&retSet, retConfiguration.l, "set",
+            "(Ljava/lang/String;Ljava/lang/String;)V", jHostKeyString, jHostString);
+    env.callMethod(&retSet, retConfiguration.l, "set",
+            "(Ljava/lang/String;Ljava/lang/String;)V", jPortKeyString, jPortString);
+
+    // Init the client context
+    env.callStaticMethod(&retClientContext, 
+          "alluxio/client/ClientContext", "init", "()V");
+
+    // Cleanup jvalues
+    env->DeleteLocalRef(jHostString);
+    env->DeleteLocalRef(jHostKeyString);
+    env->DeleteLocalRef(jPortString);
+    env->DeleteLocalRef(jPortKeyString);
+}
+
+jAlluxioCreateFileOptions AlluxioCreateFileOptions::getCreateFileOptions()
+{
+    Env env;
+    jvalue jFileOptions;
+
+    // First get the ClientContext.Configuration
+    env.callStaticMethod(&jFileOptions, 
+            "alluxio/client/file/options/CreateFileOptions", "defaults", 
+            "()Lalluxio/client/file/options/CreateFileOptions;");
+
+    return new AlluxioCreateFileOptions(env, jFileOptions.l);
+}
+
+void AlluxioCreateFileOptions::setWriteType(WriteType writeType)
+{
+    jobject jWriteType;
+    jvalue  ret;
+
+    // Get the enum value for the specified write type
+    jWriteType = enumObjWriteType(m_env, writeType);
+    
+    // Call the method to set the write type
+    m_env.callMethod(&ret, m_obj, "setWriteType", 
+            "(Lalluxio/client/WriteType;)Lalluxio/client/file/options/CreateFileOptions;",
+            jWriteType);
+}
+
+jAlluxioOpenFileOptions AlluxioOpenFileOptions::getOpenFileOptions()
+{
+    Env env;
+    jvalue jFileOptions;
+
+    // First get the ClientContext.Configuration
+    env.callStaticMethod(&jFileOptions, 
+            "alluxio/client/file/options/OpenFileOptions", "defaults", 
+            "()Lalluxio/client/file/options/OpenFileOptions;");
+
+    return new AlluxioOpenFileOptions(env, jFileOptions.l);
+}
+
+void AlluxioOpenFileOptions::setReadType(ReadType readType)
+{
+    jobject jReadType;
+    jvalue  ret;
+
+    // Get the enum value for the specified write type
+    jReadType = enumObjReadType(m_env, readType);
+    
+    // Call the method to set the write type
+    m_env.callMethod(&ret, m_obj, "setReadType", 
+            "(Lalluxio/client/ReadType;)Lalluxio/client/file/options/OpenFileOptions;",
+            jReadType);
+}
+
+jAlluxioFileSystem AlluxioFileSystem::getFileSystem(AlluxioClientContext *acc)
+{
+  Env env;
+  jvalue ret;
+
+  // might throw exception, caller needs to handle it
+  env.callStaticMethod(&ret, "alluxio/client/file/BaseFileSystem", "get", 
+                "()Lalluxio/client/file/BaseFileSystem;");
+  
+  return new AlluxioFileSystem(env, ret.l, acc);
+}
+
+jAlluxioFileSystem AlluxioFileSystem::copyClient(jAlluxioFileSystem client)
+{
+  return new AlluxioFileSystem(client->getEnv(), client->getJObj(), 
+          client->clientContext);
+}
+
+
+void AlluxioFileSystem::deletePath(const char * path)
+{
+  jvalue ret;
+
+  jAlluxioURI uri = AlluxioURI::newURI(path);
+
+  m_env.callMethod(&ret, m_obj, "delete", "(Lalluxio/AlluxioURI;)V",
+                   uri->getJObj());
+
+  delete uri;
+  return;
+}
+
+bool AlluxioFileSystem::exists(const char * path)
+{
+  jvalue ret;
+
+  jAlluxioURI uri = AlluxioURI::newURI(path);
+
+  m_env.callMethod(&ret, m_obj, "exists", "(Lalluxio/AlluxioURI;)Z",
+                   uri->getJObj());
+
+  delete uri;
+  return ret.z;
+}
+
+jFileOutStream AlluxioFileSystem::createFile(const char * path, 
+        AlluxioCreateFileOptions *options)
+{
+    jvalue ret;
+
+    jAlluxioURI uri = AlluxioURI::newURI(path);
+
+    jFileOutStream fileOutStream = NULL;
+
+    if (uri == NULL)
+    {
+       goto exit;
+    }
+
+    m_env.callMethod(&ret, m_obj, "createFile", 
+            "(Lalluxio/AlluxioURI;Lalluxio/client/file/options/CreateFileOptions;)Lalluxio/client/file/FileOutStream;",
+            uri->getJObj(), options->getOptions());
+
+    delete uri;
+
+    // FIXME: Change to shared_ptr
+    fileOutStream = new FileOutStream(m_env, ret.l); 
+
+exit:
+    return fileOutStream;
+}
+
+jFileOutStream AlluxioFileSystem::createFile(const char * path)
+{
+    jvalue ret;
+
+    jAlluxioURI uri = AlluxioURI::newURI(path);
+
+    jFileOutStream fileOutStream = NULL;
+
+    if (uri == NULL)
+    {
+       goto exit;
+    }
+
+    m_env.callMethod(&ret, m_obj, "createFile", 
+            "(Lalluxio/AlluxioURI;)Lalluxio/client/file/FileOutStream;",
+            uri->getJObj());
+
+    delete uri;
+
+    // FIXME: Change to shared_ptr
+    fileOutStream = new FileOutStream(m_env, ret.l); 
+
+exit:
+    return fileOutStream;
+}
+
+jFileInStream AlluxioFileSystem::openFile(const char * path)
+{
+    jvalue ret;
+
+    jAlluxioURI uri = AlluxioURI::newURI(path);
+
+    jFileInStream fileInStream = NULL;
+
+    if (uri == NULL)
+    {
+       goto exit;
+    }
+
+    m_env.callMethod(&ret, m_obj, "openFile", 
+            "(Lalluxio/AlluxioURI;)Lalluxio/client/file/FileInStream;",
+            uri->getJObj());
+
+    delete uri;
+    // FIXME: Change to shared_ptr?
+    fileInStream = new FileInStream(m_env, ret.l); 
+
+exit:
+    return fileInStream;
+}
+
+jFileInStream AlluxioFileSystem::openFile(const char * path, AlluxioOpenFileOptions *options)
+{
+    jvalue ret;
+
+    jAlluxioURI uri = AlluxioURI::newURI(path);
+
+    jFileInStream fileInStream = NULL;
+
+    if (uri == NULL)
+    {
+       goto exit;
+    }
+
+    m_env.callMethod(&ret, m_obj, "openFile", 
+            "(Lalluxio/AlluxioURI;Lalluxio/client/file/options/OpenFileOptions;)Lalluxio/client/file/FileInStream;",
+            uri->getJObj(), options->getOptions());
+
+    delete uri;
+
+    // FIXME: Change to shared_ptr?
+    fileInStream = new FileInStream(m_env, ret.l); 
+
+exit:
+    return fileInStream;
+}
+
+// FIXME: Rename so that deletePath and createDirectory have matching naming?
+void AlluxioFileSystem::createDirectory(const char *path)
+{
+   jvalue ret;
+   jAlluxioURI uri = AlluxioURI::newURI(path);
+
+   m_env.callMethod(&ret, m_obj, "createDirectory", 
+         "(Lalluxio/AlluxioURI;)V", uri->getJObj());
+   delete uri;
+
+exit:
+   return;
+}
+
+void AlluxioFileSystem::deletePath(const char * path, bool recursive)
+{
+  jvalue ret;
+
+  jAlluxioURI uri = AlluxioURI::newURI(path);
+
+  if (!recursive)
+  {
+     m_env.callMethod(&ret, m_obj, "delete", "(Lalluxio/AlluxioURI;)V",
+                      uri->getJObj());
+  }
+  else
+  {
+     jvalue deleteOptionsDefaults;
+     jvalue deleteOptionsSetRecursive;
+
+     m_env.callStaticMethod(&deleteOptionsDefaults, 
+           "alluxio/client/file/options/DeleteOptions", "defaults", 
+           "()Lalluxio/client/file/options/DeleteOptions;");
+
+     m_env.callMethod(&deleteOptionsSetRecursive, (jobject) deleteOptionsDefaults.l, 
+           "setRecursive", "(Z)Lalluxio/client/file/options/DeleteOptions;", 
+           (jboolean) recursive);
+
+     try
+     {
+        m_env.callMethod(&ret, m_obj, "delete", 
+              "(Lalluxio/AlluxioURI;Lalluxio/client/file/options/DeleteOptions;)V",
+              uri->getJObj(), (jobject) deleteOptionsSetRecursive.l);
+     }
+     catch (NativeException &e) 
+     {
+        std::string exceptionString;
+        jni::JavaThrowable *jthrow = e.detail();
+        jthrowable throwable = jthrow->getException();
+        m_env.throwableToString(throwable, exceptionString);
+        std::cout << "Caught exception: " << exceptionString << std::endl;
+        goto exit;
+     }
+  }
+
+exit:
+
+  delete uri;
+  return;
+}
+
+void AlluxioFileSystem::renameFile(const char *origPath, const char *newPath)
+{
+    jvalue ret;
+
+    jAlluxioURI origURI = AlluxioURI::newURI(origPath);
+    jAlluxioURI newURI = AlluxioURI::newURI(newPath);
+
+    m_env.callMethod(&ret, m_obj, "rename", 
+            "(Lalluxio/AlluxioURI;Lalluxio/AlluxioURI;)V", 
+            origURI->getJObj(), newURI->getJObj());
+
+    delete origURI;
+    delete newURI;
+}
+
+void AlluxioFileSystem::appendToFile(const char *path, void *buff, int length)
+{
+    const int bufferSize = 1000000;
+    const char* appendSuffix = ".append";
+    int bytesRead = bufferSize;
+    // FIXME: Change to std::vector
+    char* inputBuffer = (char *) calloc(bufferSize, 1);
+    int appendPathLength = strlen(path) + strlen(appendSuffix) + 1;
+
+    // FIXME: Change to std::vector
+    char* appendPath = (char *) malloc(appendPathLength);
+
+    strncpy(appendPath, path, appendPathLength);
+    strcat(appendPath,".append");
+
+    if (inputBuffer == NULL || appendPath == NULL)
+    {
+        throw std::bad_alloc();
+    }
+
+    jFileInStream origFile = openFile(path);
+
+    // FIXME: Create file should preserve file options of original file
+    jFileOutStream newFile = createFile(appendPath);
+
+    // Copy the original file over to the new file
+    while (bytesRead == bufferSize)
+    {
+        bytesRead = origFile->read(inputBuffer, bufferSize);
+
+        newFile->write(inputBuffer, bytesRead);
+    }
+
+    // Perform the append
+    newFile->write(buff, length);
+    origFile->close();
+    newFile->close();
+
+    // Delete original file
+    deletePath(path);
+
+    // NOTE: This is the critical section of this method.  If a failure
+    // occurs here, we will be left with a .append file and no original file.
+    
+    // TODO: we should add some defensive code in the open file path to
+    // perform this rename automatically if we only find a .append file
+    
+    // Rename file
+    renameFile(appendPath, path);
+
+    free(inputBuffer);
+    free(appendPath);
+}
+
+
+jByteBuffer ByteBuffer::allocate(int capacity)
+{
+  Env env;
+  jvalue ret;
+  env.callStaticMethod(&ret, BBUF_CLS, "allocate", 
+                "(I)Ljava/nio/ByteBuffer;", (jint) capacity);
+  if (ret.l == NULL)
+    return NULL;
+  return new ByteBuffer(env, ret.l);
+}
+
+//////////////////////////////////////////
+//InStream
+//////////////////////////////////////////
+
+int InStream::read()
+{
+  jvalue ret;
+  m_env.callMethod(&ret, m_obj, "read", "()I");
+  return ret.i;
+}
+
+// TODO: Template this funtion for time measurement?
+int InStream::read(void *buff, int length, int off, int maxLen, 
+      bool measureTime = false,
+      std::chrono::duration<double>* pBufferCreationTimeCounter = NULL,
+      std::chrono::duration<double>* pReadTimeCounter = NULL,
+      std::chrono::duration<double>* pBufferCopyTimeCounter = NULL)
+{
+   jbyteArray jBuf;
+   jvalue ret;
+   int rdSz;
+
+   std::chrono::duration<double> duration = std::chrono::duration<double>::zero();
+   std::chrono::time_point<std::chrono::system_clock> startTime, stopTime;
+
+   try {
+
+      if (measureTime)
+      {
+         startTime = std::chrono::system_clock::now();
+      }
+
+      jBuf = m_env.newByteArray(length);
+
+      if (measureTime)
+      {
+         stopTime = std::chrono::system_clock::now();
+         duration = stopTime - startTime;
+         *pBufferCreationTimeCounter += duration;
+      }
+
+      if (off < 0 || maxLen <= 0 || length == maxLen)
+      {
+         if (measureTime)
+         {
+            startTime = std::chrono::system_clock::now();
+         }
+
+         m_env.callMethod(&ret, m_obj, "read", "([B)I", jBuf);
+
+         if (measureTime)
+         {
+            stopTime = std::chrono::system_clock::now();
+         }
+      }
+      else
+      {
+         if (measureTime)
+         {
+            startTime = std::chrono::system_clock::now();
+         }
+
+         m_env.callMethod(&ret, m_obj, "read", "([BII)I", jBuf, off, maxLen);
+
+         if (measureTime)
+         {
+            stopTime = std::chrono::system_clock::now();
+         }
+      }
+      if (measureTime)
+      {
+         duration = stopTime - startTime;
+         *pReadTimeCounter += duration;
+      }
+   } catch (NativeException) {
+      if (jBuf != NULL) {
+         m_env->DeleteLocalRef(jBuf);
+      }
+      throw;
+   }
+   rdSz = ret.i;
+   if (rdSz > 0) {
+      if (measureTime)
+      {
+         startTime = std::chrono::system_clock::now();
+      }
+      m_env->GetByteArrayRegion(jBuf, 0, rdSz, (jbyte*) buff);
+      // TODO: It's much more efficient to get direct access to the buffer,
+      // but doing so requires the caller to create the java buffer.
+      // Create a read method that allows for this option.
+      // buff = m_env->GetDirectBufferAddress(jBuf);
+      if (measureTime)
+      {
+         stopTime = std::chrono::system_clock::now();
+         duration = stopTime - startTime;
+         *pBufferCopyTimeCounter += duration;
+      }
+   }
+   m_env->DeleteLocalRef(jBuf);
+   return rdSz;
+}
+
+int InStream::read(void *buff, int length)
+{
+  return read(buff, length, 0, length);
+}
+
+void InStream::close()
+{
+  m_env.callMethod(NULL, m_obj, "close", "()V");
+}
+
+//TODO: These methods are not yet tested yet.  Use with care
+void InStream::seek(long pos)
+{
+  m_env.callMethod(NULL, m_obj, "seek", "(J)V", (jlong) pos);
+}
+
+long InStream::skip(long n)
+{
+  jvalue ret;
+  m_env.callMethod(NULL, m_obj, "skip", "(J)J", (jlong) n);
+  return ret.j;
+}
+
+//////////////////////////////////////////
+// OutStream
+//////////////////////////////////////////
+
+void OutStream::write(int byte) 
+{
+  m_env.callMethod(NULL, m_obj, "write", "(I)V", (jint) byte);
+}
+
+void OutStream::write(const void *buff, int length)
+{
+  write(buff, length, 0, length);
+}
+
+void OutStream::write(const void *buff, int length, 
+                          int off, int maxLen)
+{
+  jthrowable exception;
+  jbyteArray jBuf;
+
+  jBuf = m_env.newByteArray(length);
+  m_env->SetByteArrayRegion(jBuf, 0, length, (jbyte*) buff);
+
+  // FIXME: Change to std::vector
+  char *jbuff = (char *) malloc(length * sizeof(char));
+  m_env->GetByteArrayRegion(jBuf, 0, length, (jbyte*) jbuff);
+
+  if (off < 0 || maxLen <= 0 || length == maxLen)
+    m_env.callMethod(NULL, m_obj, "write", "([B)V", jBuf);
+  else
+    m_env.callMethod(NULL, m_obj, "write", "([BII)V", jBuf, (jint) off, (jint) maxLen);
+  m_env->DeleteLocalRef(jBuf);
+}
+
+// Call the templates
+void OutStream::close()
+{
+  m_env.callMethod(NULL, m_obj, "close", "()V");
+}
+
+//TODO: These methods are not yet tested yet.  Use with care
+void OutStream::cancel() 
+{
+  m_env.callMethod(NULL, m_obj, "cancel", "()V");
+}
+
+void OutStream::flush()
+{
+  m_env.callMethod(NULL, m_obj, "flush", "()V");
+}
+
+//////////////////////////////////////////
+// AlluxioURI
+//////////////////////////////////////////
+
+jAlluxioURI AlluxioURI::newURI(const char *pathStr)
+{
+  Env env;
+  jobject retObj;
+  jstring jPathStr;
+  
+  jPathStr = env.newStringUTF(pathStr, "path");
+  retObj = env.newObject("alluxio/AlluxioURI", "(Ljava/lang/String;)V", jPathStr);
+  env->DeleteLocalRef(jPathStr);
+  return new AlluxioURI(env, retObj);
+}
+
+jAlluxioURI AlluxioURI::newURI(const char *scheme, const char *authority, const char *path)
+{
+  Env env;
+  jobject retObj;
+  jstring jscheme, jauthority, jpath;
+
+  jscheme = env.newStringUTF(scheme, "scheme");
+  jauthority = env.newStringUTF(authority, "authority");
+  jpath = env.newStringUTF(path, "path");
+  retObj = env.newObject("alluxio/AlluxioURI",
+                  "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V", 
+                  jscheme, jauthority, jpath);
+  env->DeleteLocalRef(jscheme);
+  env->DeleteLocalRef(jauthority);
+  env->DeleteLocalRef(jpath);
+  return new AlluxioURI(env, retObj);
+}
+
+jobject enumObjReadType(Env& env, ReadType readType)
+{
+  const char *valueName;
+  switch (readType) {
+    case NO_CACHE: 
+          valueName = "NO_CACHE";
+          break;
+    case CACHE:
+          valueName = "CACHE";
+          break;
+    case CACHE_PROMOTE:
+          valueName = "CACHE_PROMOTE";
+          break;
+    default:
+          throw std::runtime_error("invalid readType");
+  }
+  return env.getEnumObject(TREADT_CLS, valueName, "Lalluxio/client/ReadType;");
+}
+
+jobject enumObjWriteType(Env& env, WriteType writeType)
+{
+  const char *valueName;
+  switch (writeType) {
+    case ASYNC_THROUGH: 
+          valueName = "ASYNC_THROUGH";
+          break;
+    case CACHE_THROUGH:
+          valueName = "CACHE_THROUGH";
+          break;
+    case MUST_CACHE:
+          valueName = "MUST_CACHE";
+          break;
+    case THROUGH:
+          valueName = "THROUGH";
+          break;
+    default:
+          throw std::runtime_error("invalid writeType");
+  }
+  return env.getEnumObject(TWRITET_CLS, valueName, "Lalluxio/client/WriteType;");
+}
+
+
+/* vim: set ts=4 sw=4 : */

--- a/src/Alluxio.h
+++ b/src/Alluxio.h
@@ -1,0 +1,292 @@
+/**
+ *  @author        Adam Storm
+ *  @organization  IBM
+ * 
+ * Alluxio C/C++ APIs
+ *
+ */
+
+#ifndef __ALLUXIO_H_
+#define __ALLUXIO_H_
+
+#include<jni.h>
+#include<stdint.h>
+#include<chrono>
+#include<functional>
+
+#include "JNIHelper.h"
+
+#define BBUF_CLS                    "java/nio/ByteBuffer"
+
+#define TREADT_CLS                  "alluxio/client/ReadType"
+#define TWRITET_CLS                 "alluxio/client/WriteType"
+
+// TODO: While these macros have been changed (via search and replace) to
+// alluxio, they may not be used correctly yet.  No porting has been done
+// to the underlying calling functions.
+// InStream
+#define TISTREAM_CLS                "alluxio/client/InStream"
+#define TFILE_ISTREAM_CLS           "alluxio/client/FileInStream"
+#define TBLOCK_ISTREAM_CLS          "alluxio/client/BlockInStream"
+#define TLOCAL_BLOCK_ISTREAM_CLS    "alluxio/client/LocalBlockInStream"
+#define TREMOTE_BLOCK_ISTREAM_CLS   "alluxio/client/RemoteBlockInStream"
+#define TEMPTY_BLOCK_ISTREAM_CLS    "alluxio/client/EmptyBlockInStream"
+
+// OutStream
+#define TOSTREAM_CLS                "alluxio/client/OutStream"
+#define TFILE_OSTREAM_CLS           "alluxio/client/FileOutStream"
+#define TBLOCK_OSTREAM_CLS          "alluxio/client/BlockOutStream"
+
+namespace alluxio {
+
+enum ReadType {
+  NO_CACHE,
+  CACHE,
+  CACHE_PROMOTE,
+};
+
+enum WriteType {
+  ASYNC_THROUGH,
+  CACHE_THROUGH,
+  MUST_CACHE,
+  NONE,
+  THROUGH,
+};
+
+class AlluxioFileSystem;
+class AlluxioByteBuffer;
+class AlluxioCreateFileOptions;
+class AlluxioOpenFileOptions;
+class AlluxioURI;
+class ClientContext;
+class Configuration;
+
+class ByteBuffer;
+class InStream;
+class OutStream;
+class FileOutStream;
+class FileInStream;
+
+typedef AlluxioCreateFileOptions* jAlluxioCreateFileOptions;
+typedef AlluxioOpenFileOptions* jAlluxioOpenFileOptions;
+typedef Configuration* jConfiguration;
+typedef AlluxioFileSystem* jAlluxioFileSystem;
+typedef AlluxioByteBuffer* jAlluxioByteBuffer;
+typedef AlluxioURI* jAlluxioURI;
+
+typedef ByteBuffer* jByteBuffer;
+typedef InStream* jInStream;
+typedef OutStream* jOutStream;
+typedef FileOutStream* jFileOutStream;
+typedef FileInStream*  jFileInStream;
+
+class JNIObjBase {
+  public:
+    JNIObjBase(jni::Env env, jobject localObj): m_env(env) {
+      m_obj = env->NewGlobalRef(localObj);
+      // this means after the constructor, the localObj will be destroyed
+      env->DeleteLocalRef(localObj);
+    }
+
+    ~JNIObjBase() { m_env->DeleteGlobalRef(m_obj); }
+
+    jobject getJObj() { return m_obj; }
+    jni::Env& getEnv() { return m_env; }
+
+  protected:
+    jni::Env m_env;
+    jobject m_obj; // the underlying jobject
+};
+
+class AlluxioClientContext 
+{
+    // TODO: Clean up this class so that we construct first, then set the
+    // host and port after
+    public:
+        AlluxioClientContext(const char *host, const char *port);
+
+    private:
+};
+
+class AlluxioCreateFileOptions : public JNIObjBase
+{
+    public:
+        static jAlluxioCreateFileOptions getCreateFileOptions();
+        void setWriteType(WriteType writeType);
+        jobject getOptions()
+        {
+            return m_obj;
+        }
+
+    private:
+        AlluxioCreateFileOptions(jni::Env env, jobject createFileOptions) :
+            JNIObjBase(env, createFileOptions) {}
+};
+
+
+// TODO: To be implemented
+class AlluxioRenameFileOptions : public JNIObjBase
+{
+};
+
+class AlluxioOpenFileOptions : public JNIObjBase
+{
+    public:
+        static jAlluxioOpenFileOptions getOpenFileOptions();
+        void setReadType(ReadType readType);
+        jobject getOptions()
+        {
+            return m_obj;
+        }
+
+    private:
+        AlluxioOpenFileOptions(jni::Env env, jobject openFileOptions) :
+            JNIObjBase(env, openFileOptions) {}
+};
+
+class AlluxioFileSystem : public JNIObjBase {
+
+  public:
+    static jAlluxioFileSystem getFileSystem(AlluxioClientContext *acc);
+    static jAlluxioFileSystem copyClient(jAlluxioFileSystem client);
+
+    bool exists(const char *path);
+
+    jFileOutStream createFile(const char *path);
+    jFileOutStream createFile(const char *path, AlluxioCreateFileOptions *options);
+    jFileInStream openFile(const char *path);
+    jFileInStream openFile(const char *path, AlluxioOpenFileOptions *options);
+    void renameFile(const char *origPath, const char *newPath);
+
+    void renameFile(const char *origPath, const char *newPath, 
+            AlluxioRenameFileOptions *options)
+    {
+        // TODO: To be implemented
+        throw std::bad_function_call();
+    }
+
+    void appendToFile(const char *path, void *buff, int length);
+    void appendToFile(const char *path, void *buff, int length, 
+            AlluxioCreateFileOptions *options);
+    void createDirectory(const char *path);
+
+    void deletePath(const char *path);
+    void deletePath(const char *path, bool recursive);
+
+  private:
+    // hide constructor, must be instantiated using getFileSystem method
+    AlluxioFileSystem(jni::Env env, jobject tfs, AlluxioClientContext *acc) : 
+        JNIObjBase(env, tfs),
+        clientContext(acc) {}
+
+    AlluxioClientContext *clientContext;
+};
+
+class AlluxioByteBuffer : public JNIObjBase {
+  public:
+    AlluxioByteBuffer(jni::Env env, jobject tbbuf) : JNIObjBase(env, tbbuf) {}
+
+    jByteBuffer getData();
+    void close();
+
+};
+
+class ByteBuffer : public JNIObjBase {
+  public:
+    ByteBuffer(jni::Env env, jobject bbuf): JNIObjBase(env, bbuf){}
+
+    static jByteBuffer allocate(int capacity);
+};
+
+class InStream : public JNIObjBase {
+  public:
+    InStream(jni::Env env, jobject istream): JNIObjBase(env, istream){}
+  
+    void close();
+    int read();
+    int read(void *buff, int length);
+    int read(void *buff, int length, int off, int maxLen, 
+          bool measureTime,
+          std::chrono::duration<double>* pBufferCreationTimeCounter,
+          std::chrono::duration<double>* pReadTimeCounter,
+          std::chrono::duration<double>* pBufferCopyTimeCounter);
+    void seek(long pos);
+    long skip(long n);
+  
+};
+
+class FileInStream : public InStream 
+{
+   public:
+      FileInStream(jni::Env env, jobject fileInStream) : 
+         InStream (env, fileInStream){}
+};
+
+class EmptyBlockInStream : public InStream {
+};
+
+class BlockInStream : public InStream {
+};
+
+class LocalBlockInStream : public BlockInStream {
+};
+
+class RemoteBlockInStream : public BlockInStream {
+};
+
+class OutStream : public JNIObjBase {
+  public:
+    OutStream(jni::Env env, jobject ostream): JNIObjBase(env, ostream){}
+
+    void cancel();
+    void close();
+    void flush();
+    void write(int byte);
+    void write(const void *buff, int length);
+    void write(const void *buff, int length, int off, int maxLen);
+
+};
+
+class FileOutStream : public OutStream 
+{
+  public: 
+    FileOutStream(jni::Env env, jobject fileOutStream) : 
+        OutStream (env, fileOutStream){}
+};
+
+class BlockOutStream : public OutStream { 
+    bool canWrite(); //TODO
+    long getBlockId(); //TODO
+    long getBlockOffset(); //TODO
+    long getRemainingSpaceByte(); //TODO
+};
+
+class AlluxioURI : public JNIObjBase {
+  public:
+    static jAlluxioURI newURI(const char *pathStr);
+    static jAlluxioURI newURI(const char *scheme, const char *authority, const char *path);
+    static jAlluxioURI newURI(jAlluxioURI parent, jAlluxioURI child);
+
+    AlluxioURI(jni::Env env, jobject uri): JNIObjBase(env, uri){}
+};
+
+
+
+} // namespace alluxio
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+jobject enumObjReadType(alluxio::jni::Env& env, alluxio::ReadType readType);
+jobject enumObjWriteType(alluxio::jni::Env& env, alluxio::WriteType writeType);
+
+char* fullAlluxioPath(const char *masterUri, const char *filePath);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __ALLUXIO_H_ */
+
+/* vim: set ts=4 sw=4 : */

--- a/src/AlluxioTest.cc
+++ b/src/AlluxioTest.cc
@@ -1,0 +1,391 @@
+/**
+ *  @author        Adam Storm <ajstorm@ca.ibm.com>
+ *  @organization  IBM
+ * 
+ * Sample test of Alluxio C/C++ APIs
+ *
+ */
+
+#include "Alluxio.h"
+#include "Util.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+//FIXME: This is using a mix of C and C++ IO right now.  Convert to all
+// C++
+#include <fstream>
+#include <iostream>
+#include <ctime>
+#include <iomanip>
+#include <chrono>
+#include <functional>
+
+using namespace alluxio;
+
+const char * program_name;
+
+const char *masterUri;
+const char *filePath;
+
+const char *gFileToCreate = "/hello.txt";
+const char *gDirToCreate = "/alluxiotest";
+const char *gPathSeparatorString = "/";
+const char gPathSeparatorChar = '/';
+
+void usage()
+{
+   std::cerr << "Usage: " << program_name << " masterHost masterPort [file]" 
+      << std::endl;
+}
+
+char* inputFileToAlluxioPath (char* file)
+{
+    const char *fileName;
+    // Find the file name in the supplied path by looking for the last separator
+    fileName = strrchr(file, gPathSeparatorChar);
+    if (fileName == NULL)
+    {
+        // Handle the case where the supplied path is local to the directory
+        fileName = file;
+    }
+    else
+    {
+        // move past the last separator since we're explicitly adding it below
+        fileName++;
+    }
+
+    // FIXME: Change to std::vector
+    char * alluxioPath = (char *) calloc(strlen(fileName) + 
+            strlen(gPathSeparatorString) + strlen(gDirToCreate) + 1, 1);
+
+    if (!alluxioPath)
+    {
+        throw std::bad_alloc();
+    }
+
+    strncpy(alluxioPath, gDirToCreate, strlen(gDirToCreate));
+    strncpy(&alluxioPath[strlen(gDirToCreate)], gPathSeparatorString, 
+            strlen(gPathSeparatorString));
+    strncpy(&alluxioPath[strlen(gDirToCreate) + strlen(gPathSeparatorString)], 
+            fileName, strlen(fileName));
+
+    return alluxioPath;
+}
+
+void testCreateDirectory(jAlluxioFileSystem client, const char *path)
+{
+  client->createDirectory(path);
+  std::cout << "created alluxio dir " << path << std::endl;
+}
+
+jFileOutStream testCreateFileWithOptions(jAlluxioFileSystem client, const char *path)
+{
+  jFileOutStream fileOutStream;
+  bool fileExists = false;
+  AlluxioCreateFileOptions* options = AlluxioCreateFileOptions::getCreateFileOptions();
+
+  options->setWriteType(CACHE_THROUGH);
+
+  fileOutStream = client->createFile(path, options);
+
+  printf("created alluxio file:%s\n", path);
+
+  return fileOutStream;
+}
+
+jFileOutStream testCreateFile(jAlluxioFileSystem client, const char *path)
+{
+  jFileOutStream fileOutStream;
+  bool fileExists = false;
+
+  fileOutStream = client->createFile(path);
+
+  if (fileOutStream == NULL) 
+  {
+    printf("failed to create alluxio file %s\n", path);
+    goto exit;
+  }
+  else
+  {
+     printf("created alluxio file:%s\n", path);
+  }
+
+exit:
+
+  return fileOutStream;
+}
+
+void testReadLargeFile(jAlluxioFileSystem client, jFileInStream fileInStream, 
+      const char* path, char* inputBuffer, int bufferSize)
+{
+  std::chrono::duration<double> duration = std::chrono::duration<double>::zero();
+  std::chrono::duration<double> elapsedTime = std::chrono::duration<double>::zero();
+  std::chrono::duration<double> bufferCreationTime = std::chrono::duration<double>::zero();
+  std::chrono::duration<double> alluxioReadTime = std::chrono::duration<double>::zero();
+  std::chrono::duration<double> bufferCopyTime = std::chrono::duration<double>::zero();
+  std::chrono::time_point<std::chrono::system_clock> startTime, stopTime;
+  AlluxioOpenFileOptions* openOptions = AlluxioOpenFileOptions::getOpenFileOptions();
+  int bytesRead = bufferSize;
+  const bool measureTime = true;
+
+  openOptions->setReadType(CACHE_PROMOTE);
+
+  // Now do the reading from Alluxio
+  startTime = std::chrono::system_clock::now();
+  fileInStream = client->openFile(path, openOptions);
+  stopTime = std::chrono::system_clock::now();
+  duration = stopTime - startTime;
+  std::cout << "Opened file " << path << " from Alluxio in " << duration.count() 
+     << " seconds" << std::endl;
+
+  if (fileInStream == NULL) 
+  {
+     printf("failed to open alluxio file %s\n", path);
+     goto exit;
+  }
+  else
+  {
+     printf("successfully opened file:%s for reading\n", path);
+  }
+
+  elapsedTime = std::chrono::duration<double>::zero();
+
+  while (bytesRead == bufferSize)
+  {
+     startTime = std::chrono::system_clock::now();
+     bytesRead = fileInStream->read(
+           inputBuffer, bufferSize, 0, bufferSize, measureTime,
+           &bufferCreationTime, &alluxioReadTime, &bufferCopyTime);
+     stopTime = std::chrono::system_clock::now();
+     elapsedTime += stopTime - startTime;
+  }
+
+  std::cout << bufferCreationTime.count() 
+     << " seconds creating buffers" << std::endl << alluxioReadTime.count() << 
+     " seconds reading buffers" << std::endl << bufferCopyTime.count() << 
+     " seconds gaining access to buffers"<< std::endl;
+
+  fileInStream->close();
+
+  std::cout << "Read complete" << std::endl;
+  std::cout << "Spent " << elapsedTime.count() << " seconds reading from Alluxio" << std::endl;
+  delete (fileInStream); 
+
+exit:
+  return;
+}
+
+void testCopyFile(jAlluxioFileSystem client, const char *inPath, const char *alluxioPath)
+{
+  const char *fileNameInInpath;
+  jFileOutStream targetOutStream;
+  jFileInStream  fileInStream;
+  bool fileExists = false;
+  std::ifstream inputFile;
+  char *inputBuffer;
+  const int bufferSize = 1000000;
+  int bytesRead = bufferSize;
+  AlluxioCreateFileOptions* createOptions = NULL;
+  AlluxioOpenFileOptions* openOptions = NULL;
+  std::chrono::duration<double> duration = std::chrono::duration<double>::zero();
+  std::chrono::duration<double> elapsedTimeReading = std::chrono::duration<double>::zero();
+  std::chrono::duration<double> elapsedTimeWriting = std::chrono::duration<double>::zero();
+  std::chrono::time_point<std::chrono::system_clock> startTime, stopTime;
+
+  std::cout.precision(15);
+
+  createOptions = AlluxioCreateFileOptions::getCreateFileOptions();
+
+  createOptions->setWriteType(CACHE_THROUGH);
+
+  targetOutStream = client->createFile(alluxioPath, createOptions);
+
+  startTime = std::chrono::system_clock::now();
+  inputFile.open(inPath, std::ios::in | std::ios::binary);
+  stopTime = std::chrono::system_clock::now();
+  duration = stopTime - startTime;
+  std::cout << "Opened file " << inPath << " on disk in " << duration.count() 
+     << " seconds" << std::endl;
+
+  // FIXME: Change to std::vector
+  inputBuffer = (char *) calloc(bufferSize, 1);
+
+  if (!inputBuffer)
+  {
+      throw std::bad_alloc();
+  }
+
+  while (bytesRead == bufferSize)
+  {
+     startTime = std::chrono::system_clock::now();
+
+     inputFile.read(inputBuffer, bufferSize);
+
+     stopTime = std::chrono::system_clock::now();
+
+     duration = stopTime - startTime;
+
+     elapsedTimeReading += duration;
+
+     bytesRead = inputFile.gcount();
+
+     startTime = std::chrono::system_clock::now();
+
+     targetOutStream->write(inputBuffer, bytesRead);
+
+     stopTime = std::chrono::system_clock::now();
+
+     duration = stopTime - startTime;
+
+     elapsedTimeWriting += duration;
+  }
+
+  startTime = std::chrono::system_clock::now();
+  targetOutStream->close();
+  stopTime = std::chrono::system_clock::now();
+  elapsedTimeWriting += stopTime - startTime;
+
+  std::cout << "File copy complete" << std::endl;
+  std::cout << "Spent " << elapsedTimeReading.count() 
+     << " seconds reading from disk" << std::endl;
+  std::cout << "Spent " << elapsedTimeWriting.count() 
+     << " seconds writing to Alluxio" << std::endl;
+  delete(targetOutStream);
+
+  // Now do the reading from Alluxio
+  testReadLargeFile(client, fileInStream, alluxioPath, inputBuffer, bufferSize);
+
+  free(inputBuffer);
+
+  return;
+}
+
+void testAppendFile(jAlluxioFileSystem client, char* path, char* appendString)
+{
+    // TODO: This is all common code (from testCopyFile).  It should be encapsulated
+    client->appendToFile(path, appendString, strlen(appendString));
+
+    std::cout << "Successfully appended: \n\"" << appendString << "\" to file " <<
+        path << std::endl;
+}
+
+void testWriteFile(jFileOutStream fileOutStream)
+{
+  char content[] = "hello, alluxio!!\n";
+  fileOutStream->write(content, strlen(content));
+  printf("Successfully wrote %s to file\n", content);
+
+}
+
+jFileInStream testOpenFile(jAlluxioFileSystem client, const char *path)
+{
+   char *rpath;
+   jFileInStream fileInStream;
+
+   fileInStream = client->openFile(path);
+
+   printf("Successfully opened file:%s\n", path);
+
+exit:
+
+   return fileInStream;
+}
+
+void testReadFile(jFileInStream fileInStream)
+{
+  char buf[32];
+  int rdSz = fileInStream->read(buf, 31);
+  buf[rdSz] = '\0';
+  printf("Content of the created file:\n");
+  printf("%s\n", buf);
+}
+
+void testDeleteFile(jAlluxioFileSystem client, const char *path, bool recursive)
+{
+  client->deletePath(path, recursive);
+  printf("successfully deleted path %s\n", path);
+}
+
+
+int main(int argc, char*argv[])
+{
+  program_name = argv[0];
+  if (argc < 3 || argc > 4) {
+    usage();
+    exit(1);
+  }
+
+  // FIXME error checking of input params
+  char *host = argv[1];
+  char *port = argv[2];
+  char *file = NULL;
+  char appendString[] = "Successfully appended to file\n";
+
+  if (argc == 4)
+  {
+     file = argv[3];
+  }
+
+  try {
+      AlluxioClientContext acc (host, port);
+      jAlluxioFileSystem client = AlluxioFileSystem::getFileSystem(&acc);
+      if (client == NULL) {
+          die("fail to create alluxio client");
+      }
+      
+      // Test the creation of a file with the default options
+      jFileOutStream fileOutStream = testCreateFile(client, gFileToCreate);
+
+      // Close and delete created file
+      fileOutStream->close();
+      delete fileOutStream;
+      testDeleteFile(client, gFileToCreate, false);
+
+      // Test the creation of a file with non-default options
+      fileOutStream = testCreateFileWithOptions(client, gFileToCreate);
+
+      // Write to newly created file
+      testWriteFile(fileOutStream);
+
+      fileOutStream->close();
+      delete fileOutStream;
+
+      // Open file for reading
+      jFileInStream fileInStream = testOpenFile(client, gFileToCreate);
+
+      // Read from file
+      testReadFile(fileInStream);
+      fileInStream->close(); 
+      delete fileInStream; 
+
+      // Test file deletion
+      testDeleteFile(client, gFileToCreate, false);
+
+      // Test path deletion
+      testDeleteFile(client, gDirToCreate, true);
+
+      // Create a new directory
+      testCreateDirectory(client, gDirToCreate);
+
+      if (file != NULL)
+      {
+          char* alluxioFile = inputFileToAlluxioPath(file);
+
+          // Copy file (if specified) to new directory
+          testCopyFile(client, file, alluxioFile);
+
+          // Append to file
+          testAppendFile(client, alluxioFile, appendString);
+
+          free(alluxioFile);
+      }
+
+      // Cleanup
+      delete client;
+
+  } catch (const jni::NativeException &e) {
+    e.dump();
+  }
+  return 0;
+}

--- a/src/JNIHelper.cc
+++ b/src/JNIHelper.cc
@@ -15,8 +15,9 @@
 #include <cstring>
 #include <string>
 #include <sstream>
+#include <iostream>
 
-using namespace tachyon::jni;
+using namespace alluxio::jni;
 
 std::map<JNIEnv *, ClassCache *> ClassCache::s_caches;
 
@@ -435,7 +436,7 @@ jobject Env::newObjectV(jclass cls, const char *className, const char *ctorSigna
   }
 }
 
-jobject Env::getEnumObject(const char *className, const char *valueName)
+jobject Env::getEnumObject(const char *className, const char *valueName, const char *objType)
 {
   jclass cls;
   jfieldID jid;
@@ -443,10 +444,7 @@ jobject Env::getEnumObject(const char *className, const char *valueName)
 
   try {
     cls = findClassAndCache(className);
-    std::string clsSignature = className;
-    clsSignature.insert(0, 1, 'L');
-    clsSignature.push_back(';');
-    jid = m_env->GetStaticFieldID(cls, valueName, clsSignature.c_str());
+    jid = m_env->GetStaticFieldID(cls, valueName, objType);
     obj = m_env->GetStaticObjectField(cls, jid);
     checkExceptionAndClear();
   } catch (const NativeException& exce) {

--- a/src/JNIHelper.h
+++ b/src/JNIHelper.h
@@ -45,7 +45,7 @@
 #define J_OBJ    'L'
 #define J_ARRAY  '['
 
-namespace tachyon { namespace jni {
+namespace alluxio { namespace jni {
 
 /**
  * simple pthread_mutex wrapper
@@ -256,7 +256,7 @@ public:
   jobject newObject(jclass cls, const char *className, const char *ctorSignature, ...);
 
   // get the jobject for a enum value
-  jobject getEnumObject(const char *className, const char * valueName);
+  jobject getEnumObject(const char *className, const char * valueName, const char * objType);
 
   // create a runtime exception
   jthrowable newRuntimeException(const char *message);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,13 +1,26 @@
-lib_LTLIBRARIES = libtachyon.la
+lib_LTLIBRARIES = libtachyon.la liballuxio.la
 libtachyon_la_SOURCES = Tachyon.cc JNIHelper.cc Util.cc Util.h Tachyon.h
 libtachyon_la_CPPFLAGS = $(JNI_INCLUDES)
 libtachyon_la_LIBADD = $(JNI_LDFLAGS)
+liballuxio_la_SOURCES = Alluxio.cc JNIHelper.cc Util.cc Util.h Alluxio.h
+liballuxio_la_CPPFLAGS = $(JNI_INCLUDES)
+liballuxio_la_LIBADD = $(JNI_LDFLAGS)
+
 
 include_libtachyondir = $(includedir)
 include_libtachyon_HEADERS = Tachyon.h JNIHelper.h Util.h
+include_liballuxiodir = $(includedir)
+include_liballuxio_HEADERS = Alluxio.h JNIHelper.h Util.h
 
-bin_PROGRAMS = tachyontest
+bin_PROGRAMS = tachyontest alluxiotest
 
 tachyontest_SOURCES = TachyonTest.cc Util.cc Util.h Tachyon.h
 tachyontest_CPPFLAGS = $(JNI_INCLUDES)
 tachyontest_LDADD = libtachyon.la
+alluxiotest_SOURCES = AlluxioTest.cc Util.cc Util.h Alluxio.h
+alluxiotest_CPPFLAGS = $(JNI_INCLUDES)
+alluxiotest_LDADD = liballuxio.la
+
+
+
+

--- a/src/Tachyon.cc
+++ b/src/Tachyon.cc
@@ -14,7 +14,8 @@
 #include <stdlib.h>
 
 using namespace tachyon;
-using namespace tachyon::jni;
+using namespace alluxio;
+using namespace alluxio::jni;
 
 jTachyonClient TachyonClient::createClient(const char *masterUri)
 {
@@ -502,7 +503,7 @@ jobject enumObjReadType(Env& env, ReadType readType)
     default:
           throw std::runtime_error("invalid readType");
   }
-  return env.getEnumObject(TREADT_CLS, valueName);
+  return env.getEnumObject(TREADT_CLS, valueName, "Ljava/lang/String;");
 }
 
 jobject enumObjWriteType(Env& env, WriteType writeType)
@@ -527,7 +528,7 @@ jobject enumObjWriteType(Env& env, WriteType writeType)
     default:
           throw std::runtime_error("invalid writeType");
   }
-  return env.getEnumObject(TWRITET_CLS, valueName);
+  return env.getEnumObject(TWRITET_CLS, valueName, "Ljava/lang/String;");
 }
 
 char* fullTachyonPath(const char *masterUri, const char *filePath)

--- a/src/Tachyon.h
+++ b/src/Tachyon.h
@@ -41,6 +41,9 @@
 
 #define DEFAULT_KV_BLOCK_BYTES      8 * 1024 * 1024 // 8MB
 
+using namespace alluxio;
+using namespace alluxio::jni;
+
 namespace tachyon {
 
 enum ReadType {
@@ -261,8 +264,8 @@ class TachyonKV : public JNIObjBase {
 extern "C" {
 #endif
 
-jobject enumObjReadType(tachyon::jni::Env& env, tachyon::ReadType readType);
-jobject enumObjWriteType(tachyon::jni::Env& env, tachyon::WriteType writeType);
+jobject enumObjReadType(Env& env, tachyon::ReadType readType);
+jobject enumObjWriteType(Env& env, tachyon::WriteType writeType);
 
 char* fullTachyonPath(const char *masterUri, const char *filePath);
 


### PR DESCRIPTION
This is the first drop of the liballuxio code.  I've tried to keep all of the new liballuxio code separate from the original libtachyon code.  The only exception is where I've had to rename the namespace (in the JNI helper files), and one bug I found when trying to test getEnumObject and its callers (the last param should the object type, not the class signature).

For the most part, the new code is a direct port of the old code.  Some of the original functions are not yet implemented, and I've also added rename and a hacky append method which does what you'd expect considering that Alluxio doesn't natively support file appends.

There are still scattered TODOs and FIXMEs in the code, but I wanted to get this in front of some eyes before I get it fully cleaned up.

One of the big TODOs is to either move fully to C++ or C (my preference would be C++ but I'm open to a discussion).

Anyway, thanks for agreeing to have a look Ryan, and for the libtachyon starting point.
